### PR TITLE
Add (some) support for Powered Room Thermostat

### DIFF
--- a/geniushubclient/device.py
+++ b/geniushubclient/device.py
@@ -73,8 +73,12 @@ class GeniusDevice(GeniusBase):
                 dev_type = DEVICE_HASH_TO_TYPE.get(node["hash"]["val"])
                 if dev_type:
                     result["type"] = dev_type
-            elif node["SwitchBinary"]["path"].count("/") == 3:
+            elif "SwitchBinary" in node and node["SwitchBinary"]["path"].count("/") == 3:
                 result["type"] = f"Dual Channel Receiver - Channel {result['id'][-1]}"
+            elif "ThermostatMode" in node and node["ThermostatMode"]["path"].count("/") == 3:
+                result["type"] = f"Powered Room Thermostat - Channel {result['id'][-1]}"
+            elif "TEMPERATURE" in node and node["TEMPERATURE"]["path"].count("/") == 3:
+                result["type"] = f"Powered Room Thermostat - Channel {result['id'][-1]}"
             else:
                 result["type"] = None
 


### PR DESCRIPTION
Existing code gives a KeyError as neither `hash` nor `SwitchBinary` is in `node` for Powered Room Thermostats.