### PR TITLE
Update Python version to 3.11.14 in workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python 3.10.8
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10.8"
+          python-version: "3.11.14"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
The release action is failing because the version of Python isn't on the build server (I think that's what the error means).