### PR TITLE
Fix Python 3.14 compatibility and add session lifecycle management

### DIFF
--- a/geniushubclient/__init__.py
+++ b/geniushubclient/__init__.py
@@ -159,10 +159,11 @@ class GeniusHubBase:
         ) -> Tuple[List, Dict]:
             """Create the current list of GeniusHub objects (zones/devices)."""
             entities = []  # list of converted zones/devices
-            key = "id" if self.api_version == 1 else obj_key
             for raw_json in obj_list:
+                key = "id" if self.api_version == 1 else obj_key
+                entity_id = raw_json[key]
                 entity = obj_by_id.get(
-                    raw_json[key], GeniusObject(raw_json[key], raw_json, self)
+                    entity_id, GeniusObject(entity_id, raw_json, self)
                 )
                 entity._data, entity._raw = None, raw_json
                 entities.append(entity)
@@ -209,6 +210,9 @@ class GeniusHubBase:
             _LOGGER.warning("An Issue has been found: %s", issue)
         for issue in [i for i in old_issues if i not in self.issues]:
             _LOGGER.info("An Issue is now resolved: %s", issue)
+
+    async def close(self) -> None:
+        """Close the hub connection."""
 
     async def reboot(self) -> None:
         """Reboot the hub."""
@@ -258,6 +262,11 @@ class GeniusHub(GeniusHubBase):
             self.uid = auth["data"]["UID"]
 
         super().update()  # now parse all the JSON
+
+    async def close(self) -> None:
+        """Close the hub connection."""
+        if self.genius_service:
+            await self.genius_service.close()
 
 
 class GeniusTestHub(GeniusHubBase):

--- a/geniushubclient/session.py
+++ b/geniushubclient/session.py
@@ -67,6 +67,11 @@ class GeniusService:
             _LOGGER.debug("request(): response=%s", response)
         return response
 
+    async def close(self) -> None:
+        """Close the underlying session."""
+        if self._session:
+            await self._session.close()
+
     @property
     def use_v1_api(self) -> bool:
         """Return True is using the v1 API."""

--- a/ghclient.py
+++ b/ghclient.py
@@ -143,9 +143,8 @@ def _parse_args():
     return argparse.Namespace(**vars(args[0]), **vars(args_cmd))
 
 
-async def main(loop):
+async def main():
     """Return the JSON as requested."""
-
     # Option of providing test data (as list of Dicts), or leave both as None
     if FILE_MODE:
         with open("raw_zones.json", mode="r") as fh:
@@ -253,11 +252,8 @@ async def main(loop):
             if hub.api_version == 3:
                 print(f"XXX =", {"weatherData": hub.zone_by_id[0]._raw["weatherData"]})
 
-    if session:
-        await session.close()
+    await hub.close()
 
 
 if __name__ == "__main__":  # called from CLI?
-    LOOP = asyncio.get_event_loop()
-    LOOP.run_until_complete(main(LOOP))
-    LOOP.close()
+    asyncio.run(main())

--- a/tests/resource_management_test.py
+++ b/tests/resource_management_test.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import AsyncMock, patch
 from geniushubclient import GeniusHub
 
+
 class TestResourceManagement(unittest.IsolatedAsyncioTestCase):
     """Test case for GeniusHub resource management."""
 
@@ -11,23 +12,26 @@ class TestResourceManagement(unittest.IsolatedAsyncioTestCase):
         """Verify that GeniusHub.close() closes the underlying aiohttp session."""
         mock_session = AsyncMock()
         hub = GeniusHub(hub_id="test_token", session=mock_session)
-        
+
         # Verify session is the one we passed
         self.assertEqual(hub.genius_service._session, mock_session)
-        
+
         # Act
         await hub.close()
-        
+
         # Assert
         mock_session.close.assert_awaited_once()
 
     async def test_close_without_session(self):
         """Verify that GeniusHub.close() cleans up an internally created session."""
         mock_session = AsyncMock()
-        with patch("geniushubclient.session.aiohttp.ClientSession", return_value=mock_session):
+        with patch(
+            "geniushubclient.session.aiohttp.ClientSession", return_value=mock_session
+        ):
             hub = GeniusHub(hub_id="test_token")
             await hub.close()
         mock_session.close.assert_awaited_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/resource_management_test.py
+++ b/tests/resource_management_test.py
@@ -1,0 +1,33 @@
+"""Unit tests for GeniusHub resource management."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+from geniushubclient import GeniusHub
+
+class TestResourceManagement(unittest.IsolatedAsyncioTestCase):
+    """Test case for GeniusHub resource management."""
+
+    async def test_close_closes_session(self):
+        """Verify that GeniusHub.close() closes the underlying aiohttp session."""
+        mock_session = AsyncMock()
+        hub = GeniusHub(hub_id="test_token", session=mock_session)
+        
+        # Verify session is the one we passed
+        self.assertEqual(hub.genius_service._session, mock_session)
+        
+        # Act
+        await hub.close()
+        
+        # Assert
+        mock_session.close.assert_awaited_once()
+
+    async def test_close_without_session(self):
+        """Verify that GeniusHub.close() cleans up an internally created session."""
+        mock_session = AsyncMock()
+        with patch("geniushubclient.session.aiohttp.ClientSession", return_value=mock_session):
+            hub = GeniusHub(hub_id="test_token")
+            await hub.close()
+        mock_session.close.assert_awaited_once()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Proposed change

Two related fixes:

1. **Python 3.14 compatibility** — `ghclient.py` used the deprecated `asyncio.get_event_loop()` / `run_until_complete()` / `loop.close()` pattern, which is removed in Python 3.14. Replaced with `asyncio.run()`, which has been available since Python 3.7 and is therefore fully compatible with this library's declared minimum of Python 3.9. The CLI cleanup path is also updated to call `hub.close()` rather than closing the underlying session directly.

2. **Session lifecycle** — `GeniusHub` had no way to release the `aiohttp.ClientSession` it manages. Added a `close()` method to `GeniusService` (which closes the session) and to `GeniusHub` (which delegates to `GeniusService`). A no-op `close()` is also added to `GeniusHubBase` for completeness. Unit tests are included to verify both the external-session and internally-created-session cases.

## Type of change

- Bugfix (Python 3.14 compatibility)
- Code quality / resource management

## Testing

New unit tests in `tests/resource_management_test.py` cover:
- `test_close_closes_session` — verifies an externally-provided session is closed via `hub.close()`
- `test_close_without_session` — verifies an internally-created session is closed when no session is passed in